### PR TITLE
Add a UIToolkit control for displaying QR codes

### DIFF
--- a/QRCoder.Unity/QRCodeDisplay.cs
+++ b/QRCoder.Unity/QRCodeDisplay.cs
@@ -1,0 +1,115 @@
+#if ENABLE_UIELEMENTS_CONTROLS
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace QRCoder.Unity
+{
+    public class QRCodeDisplay : VisualElement
+    {
+        public QRCodeDisplay()
+        {
+            value = null;
+            style.unityBackgroundScaleMode = ScaleMode.ScaleToFit;
+        }
+
+        public void Update(string value, QRCodeGenerator.ECCLevel eccLevel, int pixelsPerModule)
+        {
+            _value = value;
+            _eccLevel = eccLevel;
+            _pixelsPerModule = pixelsPerModule;
+            RegenerateImage();
+        }
+
+        public QRCodeGenerator.ECCLevel eccLevel
+        {
+            get => _eccLevel;
+            set
+            {
+                if (_eccLevel == value)
+                    return;
+                _eccLevel = value;
+                RegenerateImage();
+            }
+        }
+
+        public int pixelsPerModule
+        {
+            get => _pixelsPerModule;
+            set
+            {
+                if (_pixelsPerModule == value)
+                    return;
+                _pixelsPerModule = value;
+                RegenerateImage();
+            }
+        }
+
+        private string _value;
+        private Texture2D _image;
+        private QRCodeGenerator.ECCLevel _eccLevel = QRCodeGenerator.ECCLevel.Q;
+        private int _pixelsPerModule = 8;
+
+        public string value
+        {
+            get => _value;
+            set
+            {
+                if (_value == value)
+                    return;
+                _value = value;
+                RegenerateImage();
+            }
+        }
+
+        private void RegenerateImage()
+        {
+            if (_image != null)
+                Object.DestroyImmediate(_image, true);
+
+            _image = null;
+
+            if (value == null)
+                return;
+
+            using var generator = new QRCodeGenerator();
+            using var data = generator.CreateQrCode(value, eccLevel);
+            var unityCode = new UnityQRCode(data);
+            _image = unityCode.GetGraphic(pixelsPerModule);
+            _image.name = "Generated QR code";
+
+            style.backgroundImage = _image;
+        }
+
+        public new class UxmlFactory : UxmlFactory<QRCodeDisplay, UxmlTraits>
+        {
+        }
+
+        public new class UxmlTraits : VisualElement.UxmlTraits
+        {
+            private UxmlStringAttributeDescription m_Value = new() { name = "value" };
+
+            private UxmlEnumAttributeDescription<QRCodeGenerator.ECCLevel> m_ECCLevel = new()
+                { name = "ecc-level", defaultValue = QRCodeGenerator.ECCLevel.Q };
+
+            private UxmlIntAttributeDescription m_PixelsPerModule = new()
+                { name = "pixels-per-module", defaultValue = 8 };
+
+            public override IEnumerable<UxmlChildElementDescription> uxmlChildElementsDescription
+            {
+                get { yield break; }
+            }
+
+            public override void Init(VisualElement ve, IUxmlAttributes bag, CreationContext cc)
+            {
+                base.Init(ve, bag, cc);
+
+                var qr = (QRCodeDisplay)ve;
+                qr.Update(m_Value.GetValueFromBag(bag, cc),
+                    m_ECCLevel.GetValueFromBag(bag, cc),
+                    m_PixelsPerModule.GetValueFromBag(bag, cc));
+            }
+        }
+    }
+}
+#endif

--- a/QRCoder.Unity/QRCodeDisplay.cs
+++ b/QRCoder.Unity/QRCodeDisplay.cs
@@ -1,4 +1,3 @@
-#if ENABLE_UIELEMENTS_CONTROLS
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -112,4 +111,3 @@ namespace QRCoder.Unity
         }
     }
 }
-#endif


### PR DESCRIPTION
This PR adds a custom UIToolkit control, which makes it easy to incorporate a QR code into a UIToolkit-based user interface. 

The control is available from the UI Builder:
<img width="324" alt="image" src="https://github.com/codebude/QRCoder.Unity/assets/588194/f90f3659-bcf2-4141-af40-6e0806fa24bd">

You can add it and edit its properties - setting a string value, the ECC level, and the pixels-per-module for rendering, directly in the UI Builder editor:

<img width="852" alt="image" src="https://github.com/codebude/QRCoder.Unity/assets/588194/42f34238-dd7a-41b1-932e-fb1e9ca82eef">

or add it via UXML directly:

```
...
    <QRCoder.Unity.QRCodeDisplay value="https://www.google.com/" ecc-level="M" pixels-per-module="8" style="height: 300px;" />
...
```

and of course you can manipulate it via code like any other VisualElement:

```
var qrCode = uiDocument.rootVisualElement.Q<QRCoder.Unity.QRCodeDisplay>("QR_CODE");
qrCode.value = "http://github.com/";
qrCode.visible = true;
```

Tested in 2022.3.18f1.